### PR TITLE
feat(abtest): support rules properties on exp allocation

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,9 +62,21 @@ if (isAllocate) {
 // Init config same as feature-flag
 ABTestClient abTest = new ABTestClientImpl(config);
 
+// Get all experiments allocated to this users within the universe id
 GetUniverseAllocationResponse universeAllocation = abTest.getUniverseAllocation(
         "qFA88l70U4RxscuJZFUwEZpHUUUF", "0b95519c-1b32-47fe-aa8c-55cb65d6f8c4");
 
+// Create properties map fo filtered experiments
+// This is optional, can be passed as the last parameter to getExperiments
+HashMap<String, String> properties = new HashMap<String, String>(1) {{
+    put("wh_code", "JK01");
+}};
+
+// Get all experiments allocated to this users within the universe id
+        GetUniverseAllocationResponse universeAllocation = abTest.getUniverseAllocation(
+        "qFA88l70U4RxscuJZFUwEZpHUUUF", "0b95519c-1b32-47fe-aa8c-55cb65d6f8c4", properties);
+        
+// Get all experiments allocated to this users in all universe
 List<GetUniverseAllocationResponse> allUniverseAllocations = abTest.getAllUniverseAllocations(
         "qFA88l70U4RxscuJZFUwEZpHUUUF");
 

--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ GetUniverseAllocationResponse universeAllocation = abTest.getUniverseAllocation(
 
 // Create properties map fo filtered experiments
 // This is optional, can be passed as the last parameter to getExperiments
+// Supported properties are defined in the Backend
 HashMap<String, String> properties = new HashMap<String, String>(1) {{
     put("wh_code", "JK01");
 }};

--- a/src/main/java/com/sayurbox/kale/abtest/ABTestClient.java
+++ b/src/main/java/com/sayurbox/kale/abtest/ABTestClient.java
@@ -4,7 +4,6 @@ import com.sayurbox.kale.abtest.client.GetUniverseAllocationResponse;
 
 import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 public interface ABTestClient {
 

--- a/src/main/java/com/sayurbox/kale/abtest/ABTestClient.java
+++ b/src/main/java/com/sayurbox/kale/abtest/ABTestClient.java
@@ -2,14 +2,16 @@ package com.sayurbox.kale.abtest;
 
 import com.sayurbox.kale.abtest.client.GetUniverseAllocationResponse;
 
-import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 public interface ABTestClient {
 
     List<GetUniverseAllocationResponse> getAllUniverseAllocations(String userId);
+
     GetUniverseAllocationResponse getUniverseAllocation(String userId, String universeId);
 
-    List<GetUniverseAllocationResponse> getAllUniverseAllocations(String userId, HashMap<String, String> properties);
-    GetUniverseAllocationResponse getUniverseAllocation(String userId, String universeId, HashMap<String, String> properties);
+    List<GetUniverseAllocationResponse> getAllUniverseAllocations(String userId, Map<String, String> properties);
+
+    GetUniverseAllocationResponse getUniverseAllocation(String userId, String universeId, Map<String, String> properties);
 }

--- a/src/main/java/com/sayurbox/kale/abtest/ABTestClient.java
+++ b/src/main/java/com/sayurbox/kale/abtest/ABTestClient.java
@@ -2,11 +2,15 @@ package com.sayurbox.kale.abtest;
 
 import com.sayurbox.kale.abtest.client.GetUniverseAllocationResponse;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 public interface ABTestClient {
 
     List<GetUniverseAllocationResponse> getAllUniverseAllocations(String userId);
     GetUniverseAllocationResponse getUniverseAllocation(String userId, String universeId);
 
+    List<GetUniverseAllocationResponse> getAllUniverseAllocations(String userId, HashMap<String, String> properties);
+    GetUniverseAllocationResponse getUniverseAllocation(String userId, String universeId, HashMap<String, String> properties);
 }

--- a/src/main/java/com/sayurbox/kale/abtest/ABTestClientImpl.java
+++ b/src/main/java/com/sayurbox/kale/abtest/ABTestClientImpl.java
@@ -6,8 +6,8 @@ import com.sayurbox.kale.abtest.command.GetUniverseAllocationCommand;
 import com.sayurbox.kale.common.KaleClientImpl;
 import com.sayurbox.kale.config.KaleConfig;
 
-import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 public class ABTestClientImpl extends KaleClientImpl implements ABTestClient {
 
@@ -34,7 +34,7 @@ public class ABTestClientImpl extends KaleClientImpl implements ABTestClient {
     }
 
     @Override
-    public List<GetUniverseAllocationResponse> getAllUniverseAllocations(String userId, HashMap<String, String> properties) {
+    public List<GetUniverseAllocationResponse> getAllUniverseAllocations(String userId, Map<String, String> properties) {
         GetAllUniverseAllocationsCommand cmd = new GetAllUniverseAllocationsCommand(this.circuitBreaker,
                 this.httpClient, this.kaleConfig.getCircuitBreakerParams().isEnabled(),
                 this.kaleConfig.getBaseUrl(),
@@ -43,7 +43,7 @@ public class ABTestClientImpl extends KaleClientImpl implements ABTestClient {
     }
 
     @Override
-    public GetUniverseAllocationResponse getUniverseAllocation(String userId, String universeId, HashMap<String, String> properties) {
+    public GetUniverseAllocationResponse getUniverseAllocation(String userId, String universeId, Map<String, String> properties) {
         GetUniverseAllocationCommand cmd = new GetUniverseAllocationCommand(this.circuitBreaker,
                 this.httpClient, this.kaleConfig.getCircuitBreakerParams().isEnabled(),
                 this.kaleConfig.getBaseUrl(),

--- a/src/main/java/com/sayurbox/kale/abtest/ABTestClientImpl.java
+++ b/src/main/java/com/sayurbox/kale/abtest/ABTestClientImpl.java
@@ -8,7 +8,6 @@ import com.sayurbox.kale.config.KaleConfig;
 
 import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 public class ABTestClientImpl extends KaleClientImpl implements ABTestClient {
 

--- a/src/main/java/com/sayurbox/kale/abtest/ABTestClientImpl.java
+++ b/src/main/java/com/sayurbox/kale/abtest/ABTestClientImpl.java
@@ -6,7 +6,9 @@ import com.sayurbox.kale.abtest.command.GetUniverseAllocationCommand;
 import com.sayurbox.kale.common.KaleClientImpl;
 import com.sayurbox.kale.config.KaleConfig;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 public class ABTestClientImpl extends KaleClientImpl implements ABTestClient {
 
@@ -19,7 +21,7 @@ public class ABTestClientImpl extends KaleClientImpl implements ABTestClient {
         GetUniverseAllocationCommand cmd = new GetUniverseAllocationCommand(this.circuitBreaker,
                 this.httpClient, this.kaleConfig.getCircuitBreakerParams().isEnabled(),
                 this.kaleConfig.getBaseUrl(),
-                userId, universeId);
+                userId, universeId, null);
         return cmd.execute();
     }
 
@@ -28,7 +30,26 @@ public class ABTestClientImpl extends KaleClientImpl implements ABTestClient {
         GetAllUniverseAllocationsCommand cmd = new GetAllUniverseAllocationsCommand(this.circuitBreaker,
                 this.httpClient, this.kaleConfig.getCircuitBreakerParams().isEnabled(),
                 this.kaleConfig.getBaseUrl(),
-                userId);
+                userId, null);
         return cmd.execute();
     }
+
+    @Override
+    public List<GetUniverseAllocationResponse> getAllUniverseAllocations(String userId, HashMap<String, String> properties) {
+        GetAllUniverseAllocationsCommand cmd = new GetAllUniverseAllocationsCommand(this.circuitBreaker,
+                this.httpClient, this.kaleConfig.getCircuitBreakerParams().isEnabled(),
+                this.kaleConfig.getBaseUrl(),
+                userId, properties);
+        return cmd.execute();
+    }
+
+    @Override
+    public GetUniverseAllocationResponse getUniverseAllocation(String userId, String universeId, HashMap<String, String> properties) {
+        GetUniverseAllocationCommand cmd = new GetUniverseAllocationCommand(this.circuitBreaker,
+                this.httpClient, this.kaleConfig.getCircuitBreakerParams().isEnabled(),
+                this.kaleConfig.getBaseUrl(),
+                userId, universeId, properties);
+        return cmd.execute();
+    }
+
 }

--- a/src/main/java/com/sayurbox/kale/abtest/command/GetAllUniverseAllocationsCommand.java
+++ b/src/main/java/com/sayurbox/kale/abtest/command/GetAllUniverseAllocationsCommand.java
@@ -5,18 +5,20 @@ import com.sayurbox.kale.abtest.client.GetUniverseAllocationResponse;
 import com.sayurbox.kale.common.client.DataResponse;
 import com.sayurbox.kale.common.command.KaleCommand;
 import io.github.resilience4j.circuitbreaker.CircuitBreaker;
-import okhttp3.OkHttpClient;
-import okhttp3.Request;
-import okhttp3.RequestBody;
-import okhttp3.Response;
+import okhttp3.*;
 
 import java.io.IOException;
+import java.lang.reflect.Type;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 public class GetAllUniverseAllocationsCommand extends KaleCommand<List<GetUniverseAllocationResponse>> {
 
     private final String userId;
+    private final Map<String, String> properties;
+    Type propertiesType = new TypeToken<HashMap<String, String>>(){}.getType();
 
     private static final String ENDPOINT = "%s/v1/abtest/allocation/%s";
 
@@ -25,10 +27,12 @@ public class GetAllUniverseAllocationsCommand extends KaleCommand<List<GetUniver
             OkHttpClient okHttpClient,
             boolean isCircuitBreakerEnabled,
             String baseUrl,
-            String userId
+            String userId,
+            Map<String, String> properties
     ) {
         super(circuitBreaker, okHttpClient, isCircuitBreakerEnabled, baseUrl);
         this.userId = userId;
+        this.properties = properties;
     }
 
     @Override
@@ -39,7 +43,10 @@ public class GetAllUniverseAllocationsCommand extends KaleCommand<List<GetUniver
     @Override
     protected Request createRequest() {
         String url = String.format(ENDPOINT, baseUrl, userId);
-        return new Request.Builder().post(RequestBody.create(null, new byte[]{})).url(url).build();
+        byte[] body = gson.toJson(properties, propertiesType).getBytes();
+        MediaType contentType = MediaType.parse("application/json");
+
+        return new Request.Builder().post(RequestBody.create(contentType, body)).url(url).build();
     }
 
     protected List<GetUniverseAllocationResponse> handleResponse(Response response) throws IOException {

--- a/src/main/java/com/sayurbox/kale/abtest/command/GetAllUniverseAllocationsCommand.java
+++ b/src/main/java/com/sayurbox/kale/abtest/command/GetAllUniverseAllocationsCommand.java
@@ -5,12 +5,15 @@ import com.sayurbox.kale.abtest.client.GetUniverseAllocationResponse;
 import com.sayurbox.kale.common.client.DataResponse;
 import com.sayurbox.kale.common.command.KaleCommand;
 import io.github.resilience4j.circuitbreaker.CircuitBreaker;
-import okhttp3.*;
+import okhttp3.MediaType;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import okhttp3.Response;
 
 import java.io.IOException;
 import java.lang.reflect.Type;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -18,7 +21,8 @@ public class GetAllUniverseAllocationsCommand extends KaleCommand<List<GetUniver
 
     private final String userId;
     private final Map<String, String> properties;
-    Type propertiesType = new TypeToken<HashMap<String, String>>(){}.getType();
+    Type propertiesType = new TypeToken<Map<String, String>>() {
+    }.getType();
 
     private static final String ENDPOINT = "%s/v1/abtest/allocation/%s";
 
@@ -43,10 +47,9 @@ public class GetAllUniverseAllocationsCommand extends KaleCommand<List<GetUniver
     @Override
     protected Request createRequest() {
         String url = String.format(ENDPOINT, baseUrl, userId);
-        byte[] body = gson.toJson(properties, propertiesType).getBytes();
         MediaType contentType = MediaType.parse("application/json");
 
-        return new Request.Builder().post(RequestBody.create(contentType, body)).url(url).build();
+        return new Request.Builder().post(RequestBody.create(contentType, gson.toJson(properties, propertiesType))).url(url).build();
     }
 
     protected List<GetUniverseAllocationResponse> handleResponse(Response response) throws IOException {
@@ -55,7 +58,8 @@ public class GetAllUniverseAllocationsCommand extends KaleCommand<List<GetUniver
             return getFallback();
         }
         DataResponse<List<GetUniverseAllocationResponse>> t = gson.fromJson(body,
-               new TypeToken<DataResponse<List<GetUniverseAllocationResponse>>>() {}.getType());
+                new TypeToken<DataResponse<List<GetUniverseAllocationResponse>>>() {
+                }.getType());
         return t.getData();
     }
 }

--- a/src/main/java/com/sayurbox/kale/abtest/command/GetUniverseAllocationCommand.java
+++ b/src/main/java/com/sayurbox/kale/abtest/command/GetUniverseAllocationCommand.java
@@ -5,17 +5,19 @@ import com.sayurbox.kale.abtest.client.GetUniverseAllocationResponse;
 import com.sayurbox.kale.common.client.DataResponse;
 import com.sayurbox.kale.common.command.KaleCommand;
 import io.github.resilience4j.circuitbreaker.CircuitBreaker;
-import okhttp3.OkHttpClient;
-import okhttp3.Request;
-import okhttp3.RequestBody;
-import okhttp3.Response;
+import okhttp3.*;
 
 import java.io.IOException;
+import java.lang.reflect.Type;
+import java.util.HashMap;
+import java.util.Map;
 
 public class GetUniverseAllocationCommand extends KaleCommand<GetUniverseAllocationResponse> {
 
     private final String userId;
     private final String universeId;
+    private final Map<String, String> properties;
+    Type propertiesType = new TypeToken<HashMap<String, String>>(){}.getType();
 
     private static final String ENDPOINT = "%s/v1/abtest/allocation/%s/%s";
 
@@ -25,11 +27,13 @@ public class GetUniverseAllocationCommand extends KaleCommand<GetUniverseAllocat
             boolean isCircuitBreakerEnabled,
             String baseUrl,
             String userId,
-            String universeId
+            String universeId,
+            Map<String, String> properties
     ) {
         super(circuitBreaker, okHttpClient, isCircuitBreakerEnabled, baseUrl);
         this.userId = userId;
         this.universeId = universeId;
+        this.properties = properties;
     }
 
     @Override
@@ -40,7 +44,10 @@ public class GetUniverseAllocationCommand extends KaleCommand<GetUniverseAllocat
     @Override
     protected Request createRequest() {
         String url = String.format(ENDPOINT, baseUrl, userId, universeId);
-        return new Request.Builder().post(RequestBody.create(null, new byte[]{})).url(url).build();
+        byte[] body = gson.toJson(properties, propertiesType).getBytes();
+        MediaType contentType = MediaType.parse("application/json");
+
+        return new Request.Builder().post(RequestBody.create(contentType, body)).url(url).build();
     }
 
     protected GetUniverseAllocationResponse handleResponse(Response response) throws IOException {

--- a/src/main/java/com/sayurbox/kale/abtest/command/GetUniverseAllocationCommand.java
+++ b/src/main/java/com/sayurbox/kale/abtest/command/GetUniverseAllocationCommand.java
@@ -5,7 +5,11 @@ import com.sayurbox.kale.abtest.client.GetUniverseAllocationResponse;
 import com.sayurbox.kale.common.client.DataResponse;
 import com.sayurbox.kale.common.command.KaleCommand;
 import io.github.resilience4j.circuitbreaker.CircuitBreaker;
-import okhttp3.*;
+import okhttp3.MediaType;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import okhttp3.Response;
 
 import java.io.IOException;
 import java.lang.reflect.Type;
@@ -17,7 +21,8 @@ public class GetUniverseAllocationCommand extends KaleCommand<GetUniverseAllocat
     private final String userId;
     private final String universeId;
     private final Map<String, String> properties;
-    Type propertiesType = new TypeToken<HashMap<String, String>>(){}.getType();
+    Type propertiesType = new TypeToken<HashMap<String, String>>() {
+    }.getType();
 
     private static final String ENDPOINT = "%s/v1/abtest/allocation/%s/%s";
 
@@ -44,10 +49,9 @@ public class GetUniverseAllocationCommand extends KaleCommand<GetUniverseAllocat
     @Override
     protected Request createRequest() {
         String url = String.format(ENDPOINT, baseUrl, userId, universeId);
-        byte[] body = gson.toJson(properties, propertiesType).getBytes();
         MediaType contentType = MediaType.parse("application/json");
 
-        return new Request.Builder().post(RequestBody.create(contentType, body)).url(url).build();
+        return new Request.Builder().post(RequestBody.create(contentType, gson.toJson(properties, propertiesType))).url(url).build();
     }
 
     protected GetUniverseAllocationResponse handleResponse(Response response) throws IOException {
@@ -56,7 +60,8 @@ public class GetUniverseAllocationCommand extends KaleCommand<GetUniverseAllocat
             return getFallback();
         }
         DataResponse<GetUniverseAllocationResponse> t = gson.fromJson(body,
-                new TypeToken<DataResponse<GetUniverseAllocationResponse>>() {}.getType());
+                new TypeToken<DataResponse<GetUniverseAllocationResponse>>() {
+                }.getType());
         return t.getData();
     }
 }

--- a/src/test/java/com/sayurbox/kale/abtest/ABTestClientImplTest.java
+++ b/src/test/java/com/sayurbox/kale/abtest/ABTestClientImplTest.java
@@ -4,11 +4,9 @@ import com.github.tomakehurst.wiremock.client.WireMock;
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import com.sayurbox.kale.abtest.client.GetUniverseAllocationResponse;
 import com.sayurbox.kale.config.KaleConfig;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.*;
 
+import java.util.HashMap;
 import java.util.List;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
@@ -99,5 +97,35 @@ public class ABTestClientImplTest {
 
         Assert.assertNotNull(actual);
         Assert.assertEquals(0, actual.size());
+    }
+
+    @Ignore("Real test on staging")
+    @Test
+    public void getUniverseAllocationRealTest_Success() {
+        KaleConfig cfg = new KaleConfig.Builder().withBaseUrl("https://kale-api.sayurbox.tech")
+                .build();
+        abTestClient = new ABTestClientImpl(cfg);
+
+        HashMap<String, String> properties = new HashMap<>();
+        properties.put("wh_code", "JK_01");
+
+        List<GetUniverseAllocationResponse> allocationsResponse = abTestClient.getAllUniverseAllocations("user-003",properties);
+        Assert.assertNotEquals(0, allocationsResponse.size());
+
+        allocationsResponse.stream().filter(a -> a.getUniverseId().equals("cd6f7e9e-4abe-41c3-bd10-3afbd14afdb2")).forEach(a -> {
+            Assert.assertEquals("user-003", a.getUserId());
+            Assert.assertEquals("cd6f7e9e-4abe-41c3-bd10-3afbd14afdb2", a.getUniverseId());
+            Assert.assertEquals("f4f56090-5a1d-49d6-899b-1ce5178f7d5d", a.getExperimentId());
+        });
+
+        // Test without properties
+        allocationsResponse = abTestClient.getAllUniverseAllocations("user-003");
+        Assert.assertNotEquals(0, allocationsResponse.size());
+
+        allocationsResponse.stream().filter(a -> a.getUniverseId().equals("cd6f7e9e-4abe-41c3-bd10-3afbd14afdb2")).forEach(a -> {
+            Assert.assertEquals("user-003", a.getUserId());
+            Assert.assertEquals("cd6f7e9e-4abe-41c3-bd10-3afbd14afdb2", a.getUniverseId());
+            Assert.assertEquals("f4f56090-5a1d-49d6-899b-1ce5178f7d5d", a.getExperimentId());
+        });
     }
 }

--- a/src/test/java/com/sayurbox/kale/abtest/ABTestClientImplTest.java
+++ b/src/test/java/com/sayurbox/kale/abtest/ABTestClientImplTest.java
@@ -4,13 +4,19 @@ import com.github.tomakehurst.wiremock.client.WireMock;
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import com.sayurbox.kale.abtest.client.GetUniverseAllocationResponse;
 import com.sayurbox.kale.config.KaleConfig;
-import org.junit.*;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Rule;
+import org.junit.Test;
 
 import java.util.HashMap;
 import java.util.List;
 
-import static com.github.tomakehurst.wiremock.client.WireMock.*;
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 
 public class ABTestClientImplTest {
 
@@ -142,7 +148,7 @@ public class ABTestClientImplTest {
                                 "\"experiment_id\":\"experiment-003\",\"variant_id\":\"variant-003\"," +
                                 "\"configs\":[{\"key\":\"color\",\"value\":\"red\"}]}]}")
                 ));
-        List<GetUniverseAllocationResponse> actual = abTestClient.getAllUniverseAllocations("user-003",properties);
+        List<GetUniverseAllocationResponse> actual = abTestClient.getAllUniverseAllocations("user-003", properties);
         GetUniverseAllocationResponse alloc = actual.get(0);
 
         Assert.assertEquals("user-003", alloc.getUserId());
@@ -164,7 +170,7 @@ public class ABTestClientImplTest {
         HashMap<String, String> properties = new HashMap<>();
         properties.put("wh_code", "JK_01");
 
-        List<GetUniverseAllocationResponse> allocationsResponse = abTestClient.getAllUniverseAllocations("user-003",properties);
+        List<GetUniverseAllocationResponse> allocationsResponse = abTestClient.getAllUniverseAllocations("user-003", properties);
         Assert.assertNotEquals(0, allocationsResponse.size());
 
         allocationsResponse.stream().filter(a -> a.getUniverseId().equals("cd6f7e9e-4abe-41c3-bd10-3afbd14afdb2")).forEach(a -> {

--- a/src/test/java/com/sayurbox/kale/abtest/ABTestClientImplTest.java
+++ b/src/test/java/com/sayurbox/kale/abtest/ABTestClientImplTest.java
@@ -102,7 +102,8 @@ public class ABTestClientImplTest {
     @Ignore("Real test on staging")
     @Test
     public void getUniverseAllocationRealTest_Success() {
-        KaleConfig cfg = new KaleConfig.Builder().withBaseUrl("https://kale-api.sayurbox.tech")
+        // TODO: change with staging endpoint
+        KaleConfig cfg = new KaleConfig.Builder().withBaseUrl("http://localhost:9494")
                 .build();
         abTestClient = new ABTestClientImpl(cfg);
 

--- a/src/test/java/com/sayurbox/kale/abtest/ABTestClientImplTest.java
+++ b/src/test/java/com/sayurbox/kale/abtest/ABTestClientImplTest.java
@@ -99,6 +99,60 @@ public class ABTestClientImplTest {
         Assert.assertEquals(0, actual.size());
     }
 
+
+    @Test
+    public void getUniverseAllocationWithProperties_Success() {
+        HashMap<String, String> properties = new HashMap<String, String>(1) {{
+            put("wh_code", "JK01");
+        }};
+
+        stubFor(post(urlEqualTo("/v1/abtest/allocation/user-003/universe-003"))
+                .withRequestBody(WireMock.equalToJson("{\"wh_code\":\"JK01\"}"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("{\"data\":{\"user_id\":\"user-003\",\"universe_id\":\"universe-003\"," +
+                                "\"experiment_id\":\"experiment-003\",\"variant_id\":\"variant-003\"," +
+                                "\"configs\":[{\"key\":\"color\",\"value\":\"red\"}]}}")
+                ));
+        GetUniverseAllocationResponse actual = abTestClient.getUniverseAllocation(
+                "user-003", "universe-003", properties
+        );
+
+        Assert.assertEquals("user-003", actual.getUserId());
+        Assert.assertEquals("universe-003", actual.getUniverseId());
+        Assert.assertEquals("experiment-003", actual.getExperimentId());
+        Assert.assertEquals("variant-003", actual.getVariantId());
+        Assert.assertEquals("color", actual.getConfigs().get(0).get("key"));
+        Assert.assertEquals("red", actual.getConfigs().get(0).get("value"));
+    }
+
+    @Test
+    public void getAllUniverseAllocationsWithProperties_Success() {
+        HashMap<String, String> properties = new HashMap<String, String>(1) {{
+            put("wh_code", "JK01");
+        }};
+
+        stubFor(post(urlEqualTo("/v1/abtest/allocation/user-003"))
+                .withRequestBody(WireMock.equalToJson("{\"wh_code\":\"JK01\"}"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("{\"data\":[{\"user_id\":\"user-003\",\"universe_id\":\"universe-003\"," +
+                                "\"experiment_id\":\"experiment-003\",\"variant_id\":\"variant-003\"," +
+                                "\"configs\":[{\"key\":\"color\",\"value\":\"red\"}]}]}")
+                ));
+        List<GetUniverseAllocationResponse> actual = abTestClient.getAllUniverseAllocations("user-003",properties);
+        GetUniverseAllocationResponse alloc = actual.get(0);
+
+        Assert.assertEquals("user-003", alloc.getUserId());
+        Assert.assertEquals("universe-003", alloc.getUniverseId());
+        Assert.assertEquals("experiment-003", alloc.getExperimentId());
+        Assert.assertEquals("variant-003", alloc.getVariantId());
+        Assert.assertEquals("color", alloc.getConfigs().get(0).get("key"));
+        Assert.assertEquals("red", alloc.getConfigs().get(0).get("value"));
+    }
+
     @Ignore("Real test on staging")
     @Test
     public void getUniverseAllocationRealTest_Success() {


### PR DESCRIPTION
## Summary
Adding optional properties parameters to both getExperiments method to support filtered abTesting
- getAllUniverseAllocations(String userId, HashMap<String, String> properties)
- getUniverseAllocation(String userId, String universeId, HashMap<String, String> properties)